### PR TITLE
Fix: 팀 프로필 삭제시 마이페이지로 가지지 않는 이슈 해결, 내 프로필은 마이페이지로 이동하도록 수정, 뒤로가기시 해당 …

### DIFF
--- a/src/components/communityComponents/TeamBuilding/CardList.tsx
+++ b/src/components/communityComponents/TeamBuilding/CardList.tsx
@@ -1,22 +1,24 @@
 import { useNavigate } from "react-router-dom";
 
-import { TTeamBuildPostListItem, TTeamBuildProfileListItem } from "../../../types";
+import { TTeamBuildPostListItem, TTeamBuildProfileListItem, TUserData } from "../../../types";
 
 import defaultProfile from "../../../assets/common/defaultProfile.svg";
 
 type TeamBuildCardProps = {
   postType: "teamBuild";
   post: TTeamBuildPostListItem;
+  userData?: TUserData;
 };
 
 type ProfileCardProps = {
   postType: "profile";
   post: TTeamBuildProfileListItem;
+  userData: TUserData | undefined;
 };
 
 type Props = TeamBuildCardProps | ProfileCardProps;
 
-export default function CardList({ postType, post }: Props) {
+export default function CardList({ postType, post, userData }: Props) {
   const navigate = useNavigate();
 
   const purpose =
@@ -39,14 +41,20 @@ export default function CardList({ postType, post }: Props) {
 
   const career = post?.career === "STUDENT" ? "대학생" : post?.career === "JOBSEEKER" ? "취준생" : "현직자";
 
+  const isMyProfile = post?.author_data.id === userData?.user_id;
+  const handleProfileNavigate = () => {
+    if (isMyProfile) {
+      navigate(`/my-page/${userData?.user_id}?tab=teambuilding`);
+    } else {
+      navigate(`/community/team-building/profile-detail/${post.author_data.id}`);
+    }
+  };
   return (
     <section
       key={post?.id}
       className=" relative h-[500px] flex flex-col border-gray-100 border-[0.7px] rounded-lg border-solid cursor-pointer"
       onClick={() => {
-        postType === "profile"
-          ? navigate(`/community/team-building/profile-detail/${post.author_data.id}`)
-          : navigate(`/community/team-building/team-recruit/${post.id}`);
+        postType === "profile" ? handleProfileNavigate() : navigate(`/community/team-building/team-recruit/${post.id}`);
       }}
     >
       <div className="h-[55%] relative">

--- a/src/components/communityComponents/TeamBuilding/Profile/ProfileDetail.tsx
+++ b/src/components/communityComponents/TeamBuilding/Profile/ProfileDetail.tsx
@@ -24,7 +24,7 @@ type MyPageProps = {
 type TeamBuildingProfileProps = {
   profileData?: TTeamBuildProfileListItem;
   user?: TUserData;
-  isMyPage?: false;
+  isMyPage?: boolean | null;
 };
 
 type Props = MyPageProps | TeamBuildingProfileProps;

--- a/src/components/communityComponents/TeamBuilding/RenderPosts.tsx
+++ b/src/components/communityComponents/TeamBuilding/RenderPosts.tsx
@@ -1,10 +1,11 @@
-import { TTeamBuildPostListItem, TTeamBuildProfileListItem } from "../../../types";
+import { TTeamBuildPostListItem, TTeamBuildProfileListItem, TUserData } from "../../../types";
 import CardList from "./CardList";
 
 type TabContentProps = {
   posts: TTeamBuildPostListItem[] | TTeamBuildProfileListItem[] | undefined;
   searchPosts: TTeamBuildPostListItem[] | TTeamBuildProfileListItem[] | undefined;
   searchKeyword: string;
+  userData: TUserData | undefined;
   noPostsMessage: string;
   noSearchResultsMessage: string;
   cardType: "teamBuild" | "profile";
@@ -14,6 +15,7 @@ export default function RenderPosts({
   posts,
   searchPosts,
   searchKeyword,
+  userData,
   noPostsMessage,
   noSearchResultsMessage,
   cardType,
@@ -31,14 +33,14 @@ export default function RenderPosts({
         cardType === "teamBuild" ? (
           <CardList key={post.id} postType="teamBuild" post={post as TTeamBuildPostListItem} />
         ) : (
-          <CardList key={post.id} postType="profile" post={post as TTeamBuildProfileListItem} />
+          <CardList key={post.id} postType="profile" post={post as TTeamBuildProfileListItem} userData={userData} />
         ),
       )
     : posts?.map((post) =>
         cardType === "teamBuild" ? (
           <CardList key={post.id} postType="teamBuild" post={post as TTeamBuildPostListItem} />
         ) : (
-          <CardList key={post.id} postType="profile" post={post as TTeamBuildProfileListItem} />
+          <CardList key={post.id} postType="profile" post={post as TTeamBuildProfileListItem} userData={userData} />
         ),
       );
 }

--- a/src/components/mypageComponents/MyGame.tsx
+++ b/src/components/mypageComponents/MyGame.tsx
@@ -9,7 +9,7 @@ import { useParams } from "react-router-dom";
 
 type TMyGameProps = {
   user: TUserData;
-  isMyPage: boolean;
+  isMyPage: boolean | null;
 };
 
 const MyGame = (props: TMyGameProps) => {

--- a/src/components/mypageComponents/ProfileHeader.tsx
+++ b/src/components/mypageComponents/ProfileHeader.tsx
@@ -13,7 +13,7 @@ type NavigationType = "log" | "teambuilding" | "develop" | "setting";
 
 type TProfileProps = {
   user: TUserData;
-  isMyPage: boolean;
+  isMyPage: boolean | null;
   setNavigation: React.Dispatch<React.SetStateAction<NavigationType>>;
 };
 

--- a/src/page/MyPage.tsx
+++ b/src/page/MyPage.tsx
@@ -26,10 +26,12 @@ const MyPage = () => {
   };
 
   const { userData } = userStore();
-
-  const isMyPage = id === userData?.data.user_id.toString();
+  const isUserDataLoaded = !!userData?.data?.user_id;
+  const isMyPage = isUserDataLoaded ? id === userData.data.user_id.toString() : null;
 
   useEffect(() => {
+    if (!isUserDataLoaded) return;
+
     if (!isMyPage) {
       window.alert("잘못된 접근입니다.");
       navigate("/", { replace: true });

--- a/src/page/TeamBuilding.tsx
+++ b/src/page/TeamBuilding.tsx
@@ -24,8 +24,6 @@ import pixelMeteor from "../assets/homeImage/pixelMeteor.svg";
 import balloon from "../assets/headerImage/balloon.svg";
 import RenderPosts from "../components/communityComponents/TeamBuilding/RenderPosts";
 
-type TabValue = "teamRecruit" | "profileRegister";
-
 type FilterCategory = "position" | "purpose" | "period";
 
 interface SelectedFilter {
@@ -33,27 +31,51 @@ interface SelectedFilter {
   value: string;
   label: string;
 }
-const TAB_LABELS: Record<TabValue, string> = {
+const TAB_LABELS = {
   teamRecruit: "팀원 모집",
   profileRegister: "프로필 등록",
 };
 
+type TabValue = keyof typeof TAB_LABELS; // 'teamRecruit' | 'profileRegister'
+
 export default function TeamBuilding() {
   const COUNT_PER_PAGE = 12;
 
-  const [selectedTab, setSelectedTab] = useState<TabValue>("teamRecruit");
   const [selectedFilters, setSelectedFilters] = useState<SelectedFilter[]>([]);
   const [searchKeyword, setSearchKeyword] = useState("");
   const [searchKeywordProfile, setSearchKeywordProfile] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const params = new URLSearchParams();
 
   const { userData } = userStore();
   const { currentPage, onChangePage } = usePageHandler();
 
   const openParam = isOpen ? "open" : "";
-  const params = new URLSearchParams();
+
+  const queryTab = searchParams.get("tab") as TabValue | null;
+  const DEFAULT_TAB: TabValue = "teamRecruit";
+
+  const [selectedTab, setSelectedTab] = useState<TabValue>(queryTab ?? DEFAULT_TAB);
+
+  useEffect(() => {
+    if (selectedTab === "profileRegister" || selectedTab === "teamRecruit") {
+      setSelectedFilters([]);
+      setSearchKeyword("");
+    }
+  }, [selectedTab]);
+
+  useEffect(() => {
+    if (queryTab && queryTab in TAB_LABELS) {
+      setSelectedTab(queryTab);
+    }
+  }, [queryTab]);
+
+  const handleTabChange = (tab: TabValue) => {
+    setSelectedTab(tab);
+    setSearchParams({ tab });
+  };
 
   selectedFilters.forEach((filter) => {
     if (filter.category === "position") params.append("roles", filter.value);
@@ -147,14 +169,6 @@ export default function TeamBuilding() {
     setSearchKeywordProfile(e.currentTarget.value);
   };
 
-  useEffect(() => {
-    if (selectedTab === "profileRegister" || selectedTab === "teamRecruit") {
-      setSelectedFilters([]);
-      setSearchKeyword("");
-      setSearchParams("");
-    }
-  }, [selectedTab]);
-
   return (
     <main>
       <div className="bg-gray-800 w-full">
@@ -180,10 +194,9 @@ export default function TeamBuilding() {
             </div>
           )}
         </div>
-
         {/* 팀원모집/ 프로필 선택, 검색 영역 */}
         <div className="flex items-center justify-between mx-auto mt-16 max-w-[1440px]">
-          <SpartaTabNav selectedTab={selectedTab} onTabChange={setSelectedTab} tabLabels={TAB_LABELS} />
+          <SpartaTabNav selectedTab={selectedTab} onTabChange={handleTabChange} tabLabels={TAB_LABELS} />
           <div className="flex gap-4 px-6 py-5 rounded-full bg-gray-800">
             <img src={balloon} alt="검색 아이콘" />
             <input
@@ -194,7 +207,6 @@ export default function TeamBuilding() {
             />
           </div>
         </div>
-
         {/* 필터링, 글 등록 영역 */}
         <SearchFilter
           userData={userData?.data}
@@ -207,7 +219,6 @@ export default function TeamBuilding() {
           setIsOpen={setIsOpen}
           updateSearchParams={updateSearchParams}
         />
-
         {/* 포스트 리스트 영역 */}
         <div className="grid grid-cols-4 gap-5">
           {selectedTab === "teamRecruit" && (
@@ -215,6 +226,7 @@ export default function TeamBuilding() {
               posts={teamBuildPosts}
               searchPosts={searchTeambuildPosts}
               searchKeyword={searchKeyword}
+              userData={userData?.data}
               noPostsMessage="아직 등록된 팀빌딩 모집글이 없습니다."
               noSearchResultsMessage="검색 결과가 없습니다."
               cardType="teamBuild"
@@ -226,13 +238,13 @@ export default function TeamBuilding() {
               posts={teamBuildProfilePosts}
               searchPosts={searchTeambuildProfilePosts}
               searchKeyword={searchKeywordProfile}
+              userData={userData?.data}
               noPostsMessage="아직 등록된 팀빌딩 프로필이 없습니다."
               noSearchResultsMessage="검색 결과가 없습니다."
               cardType="profile"
             />
           )}
         </div>
-
         <div className="mt-10">
           <SpartaPagination
             dataTotalCount={data?.pagination.count}


### PR DESCRIPTION
- 팀 프로필 삭제 후 마이페이지로 이동될 때 '잘못된 접근입니다.' 알림창 뜨는 이슈 해결
- 내 팀 프로필을 클릭했을 시, 마이 페이지 내의 팀 빌딩 프로필 화면으로 가도롱 수정
- 팀 빌딩 프로필 탭에서 글 등록 혹은 팀 프로필 클릭 후 뒤로가기 했을 시에 팀 빌딩 프로필 탭이 선택된 화면이 그대로 유지되도록 수정(팀 모집도 마찬가지)